### PR TITLE
Fix UMD build error when installing using Yarn 4 (temp)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,13 +19,14 @@ export default defineConfig({
 			libBuild: {
 				buildOptions: {
 					rollupOptions: {
-						external: ['react', /@mui\/.*/],
+						external: ['react', /@mui\/.*/, 'use-resize-observer'],
 						output: {
 							globals: {
 								react: 'React',
 								'@mui/material/CircularProgress': 'MaterialUI.CircularProgress',
 								'@mui/material/SvgIcon': 'MaterialUI.SvgIcon',
 								'@mui/material/styles/styled': 'MaterialUI.styled',
+								'use-resize-observer': 'UseResizeObserver',
 							},
 						},
 					},


### PR DESCRIPTION
- Externalize `use-resize-observer` for UMD build for Yarn 4. Leaving aside the contradiction of  `use-resize-observer` not having UMD build...

# Remarks
- Do we really need UMD? Anyone using this please comment.
- Need to consider moving `use-resize-observer` from peerDependencies to dependencies for more permanent fix.